### PR TITLE
Joeldebruijn patch 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ The post content follows the YAML header. Below is an example
 title: 'Maintaining a static self-hosted site'
 date: 'Sun, 19 Apr 2020 08:42:00 +0000'
 categories: [documentation]
-tags: [static, self-hosted, markdown]
+keywords: [static, self-hosted, markdown]
 ---
 post content
 ```

--- a/ssst
+++ b/ssst
@@ -571,7 +571,7 @@ def parse_date (s) -> datetime.date:
        - s: string to parse if it isn't a date
     """
     if type(s) is str:
-        time = datetime.datetime.strptime(s,'%a, %d %b %Y %H:%M:%S %z')
+        time = datetime.datetime.strptime(s,'%Y-%m-%dT%H:%M:%S')
         return time.date()
     else:
         return s


### PR DESCRIPTION
Dont know if this is the rigth way, little experience with Git and all.

The ssst script gave a wrong date-time format error, when the Yaml header uses ISO8601.
So this proposes another format string in line 574.

Also the Yaml example uses the word ' tag'  instead of 'keywords' which I think it expects.